### PR TITLE
Fix sniff tests to account for changing spacy models

### DIFF
--- a/tests/pretrained/allennlp_pretrained_test.py
+++ b/tests/pretrained/allennlp_pretrained_test.py
@@ -78,33 +78,6 @@ class AllenNlpPretrainedTest(AllenNlpTestCase):
                 ],
             },
             {
-                "verb": "were",
-                "description": "If you liked the music we [V: were] playing last night , you will absolutely love what we 're playing tomorrow !",
-                "tags": [
-                    "O",
-                    "O",
-                    "O",
-                    "O",
-                    "O",
-                    "O",
-                    "B-V",
-                    "O",
-                    "O",
-                    "O",
-                    "O",
-                    "O",
-                    "O",
-                    "O",
-                    "O",
-                    "O",
-                    "O",
-                    "O",
-                    "O",
-                    "O",
-                    "O",
-                ],
-            },
-            {
                 "verb": "playing",
                 "description": "If you liked [ARG1: the music] [ARG0: we] were [V: playing] [ARGM-TMP: last] night , you will absolutely love what we 're playing tomorrow !",
                 "tags": [
@@ -182,33 +155,6 @@ class AllenNlpPretrainedTest(AllenNlpTestCase):
                     "I-ARG1",
                     "I-ARG1",
                     "I-ARG1",
-                    "O",
-                ],
-            },
-            {
-                "verb": "'re",
-                "description": "If you liked the music we were playing last night , you will absolutely love what we [V: 're] playing tomorrow !",
-                "tags": [
-                    "O",
-                    "O",
-                    "O",
-                    "O",
-                    "O",
-                    "O",
-                    "O",
-                    "O",
-                    "O",
-                    "O",
-                    "O",
-                    "O",
-                    "O",
-                    "O",
-                    "O",
-                    "O",
-                    "O",
-                    "B-V",
-                    "O",
-                    "O",
                     "O",
                 ],
             },
@@ -382,7 +328,7 @@ class AllenNlpPretrainedTest(AllenNlpTestCase):
         ]
         assert (
             result["trees"]
-            == "(S (S (NP (NNP Pierre) (NNP Vinken)) (VP (VBD died) (NP (JJ aged) (CD 81)))) (: ;) (S (VP (VBN immortalised) (S (ADJP (VBN aged) (NP (CD 61)))))) (. .))"
+            == "(S (NP (NNP Pierre) (NNP Vinken)) (VP (VP (VBD died) (NP (JJ aged) (CD 81))) (, ;) (VP (VBN immortalised) (S (ADJP (JJ aged) (CD 61))))) (. .))"
         )
 
     def test_dependency_parsing(self):


### PR DESCRIPTION
- Amalgamation of fixes from https://github.com/allenai/allennlp/pull/3468 and https://github.com/allenai/allennlp/pull/3432.
- We weren't able to simply swap in a simpler tokenizer because these tests rely on a pos tagger. Spacy is probably a sane default for that according to @DeNeutoy.
- Version details for testing locally:
```
(allennlp-hub) brendanr.local ➜  allennlp-hub git:(fix_sniff) ✗ ipython
impPython 3.6.9 |Anaconda, Inc.| (default, Jul 30 2019, 13:42:17)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.9.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import spacy

In [2]: spacy.__version__
Out[2]: '2.2.2'
(allennlp-hub) brendanr.local ➜  allennlp-hub git:(fix_sniff) ✗ python -m spacy validate
✔ Loaded compatibility table

====================== Installed models (spaCy v2.2.2) ======================
ℹ spaCy installation:
/Users/brendanr/anaconda3/envs/allennlp-hub/lib/python3.6/site-packages/spacy

TYPE      NAME             MODEL            VERSION
package   en-core-web-sm   en_core_web_sm   2.2.5   ✔
```